### PR TITLE
Use ts node for tests execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Supported browsers [Chrome](https://www.google.com/chrome)
 
 ####Install and run tests
 ```npm install``` install all dependencies
-```npm run start:sampleApp``` spin up the sample app page for testings
+```npm run start:sampleApp``` spin up the sample app page for testing
 ```npm test``` execute all tests
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ Util that blends [WebdriverIO](http://webdriver.io/ "WebdriverIO"), [TypeScript]
 ##Getting Started
 You need to install [Java JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html) 8 or above, [NodeJS](https://nodejs.org/en/download)
 
-Supported browsers [Chrome](https://www.google.com/chrome) and [Firefox](https://www.mozilla.org/en-US/firefox/new)
+Supported browsers [Chrome](https://www.google.com/chrome)
+
+####Install and run tests
+```npm install``` install all dependencies
+```npm run start:sampleApp``` spin up the sample app page for testings
+```npm test``` execute all tests
 
 ## Project Structure
 
@@ -27,7 +32,7 @@ Common utils for tests such as getRandomString()
 
 ### SpecialKeys
 
-Holds keyboard's special keys
+Holds keyboard special keys
 
 ### Environment variables
 ```PRINT_LOGS_TO_CONSOLE``` - false by default. only enabled in dev configuration, since parallel tests execution will log to same terminal

--- a/README.md
+++ b/README.md
@@ -13,8 +13,17 @@ Supported browsers [Chrome](https://www.google.com/chrome)
 
 ####Install and run tests
 ```npm install``` install all dependencies
+
 ```npm run start:sampleApp``` spin up the sample app page for testing
+
 ```npm test``` execute all tests
+
+```npm run spec <spec name>``` to execute specific spec file 
+
+### Environment variables
+```PRINT_LOGS_TO_CONSOLE``` - false by default. only enabled in dev configuration, since parallel tests execution will log to same terminal
+
+```DEFAULT_TIME_OUT``` - timeout for webdriverIO actions. Default value 60 seconds
 
 ## Project Structure
 
@@ -33,10 +42,6 @@ Common utils for tests such as getRandomString()
 ### SpecialKeys
 
 Holds keyboard special keys
-
-### Environment variables
-```PRINT_LOGS_TO_CONSOLE``` - false by default. only enabled in dev configuration, since parallel tests execution will log to same terminal
-```DEFAULT_TIME_OUT``` - timeout for webdriverIO actions. Default value 60 seconds
 
 ## Example With Pure WebdriverIO
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -450,6 +450,11 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
     "@types/mime-types": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
@@ -1102,6 +1107,11 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -3400,6 +3410,14 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
@@ -5032,6 +5050,11 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "make-plural": {
       "version": "6.0.1",
@@ -6720,6 +6743,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
@@ -7178,6 +7210,43 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "ts-node": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+      "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        }
+      }
     },
     "tslib": {
       "version": "1.9.3",
@@ -8062,6 +8131,11 @@
       "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.2.1.tgz",
       "integrity": "sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==",
       "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "zip-stream": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prepack": "npm run tslint && tsc && cp -R src/helpers/ lib/helpers",
     "setChromeDriverVersion": "./src/scripts/setChromeDriverVersion.sh",
     "test": "DEFAULT_TIME_OUT=3000 npm run setChromeDriverVersion; wdio src/test/wdio.conf.js --suite regression",
-    "test:spec": "DEFAULT_TIME_OUT=3000 wdio src/test/wdio.conf.js --spec",
+    "spec": "DEFAULT_TIME_OUT=3000 wdio src/test/wdio.conf.js --spec",
     "pretest": "npm run tslint",
     "start:sampleApp": "ws --spa src/test/sampleApp/index.html"
   },

--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
     "examples"
   ],
   "scripts": {
+    "compile": "npm run prettier && npm run tslint",
     "tslint": "tslint -c tslint.json 'src/**/*.ts' -p ./ --fix",
-    "clean": "rm -rf ./lib",
     "prettier": "prettier --write 'src/**/*.ts'; prettier --write 'src/test/**/*.ts'",
-    "prepare": "npm run clean && npm run prettier && npm run tslint && tsc && cp -R src/helpers/ lib/helpers",
-    "compile": "npm run prettier && npm run tslint && tsc",
+    "prepack": "tsc && cp -R src/helpers/ lib/helpers",
     "setChromeDriverVersion": "./src/scripts/setChromeDriverVersion.sh",
-    "test": "npm run compile && npm run setChromeDriverVersion && wdio src/test/wdio.conf.js --suite regression",
+    "test": "npm run setChromeDriverVersion && wdio src/test/wdio.conf.js --suite regression",
     "spec": "wdio src/test/wdio.conf.js --spec",
     "start:sampleApp": "ws --spa src/test/sampleApp/index.html"
   },
@@ -55,6 +54,8 @@
     "dotenv": "^8.2.0",
     "lodash": "^4.17.15",
     "request-promise-native": "^1.0.8",
+    "ts-node": "^8.10.2",
+    "tsconfig-paths": "^3.9.0",
     "wdio-docker-service": "2.3.1",
     "wdio-image-comparison-service": "1.12.2",
     "webdriverio": "5.18.6",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,12 @@
     "examples"
   ],
   "scripts": {
-    "compile": "npm run prettier && npm run tslint",
     "tslint": "tslint -c tslint.json 'src/**/*.ts' -p ./ --fix",
     "prettier": "prettier --write 'src/**/*.ts'; prettier --write 'src/test/**/*.ts'",
-    "prepack": "tsc && cp -R src/helpers/ lib/helpers",
+    "prepack": "npm run tslint && tsc && cp -R src/helpers/ lib/helpers",
     "setChromeDriverVersion": "./src/scripts/setChromeDriverVersion.sh",
-    "test": "npm run setChromeDriverVersion && wdio src/test/wdio.conf.js --suite regression",
-    "spec": "wdio src/test/wdio.conf.js --spec",
+    "test": "DEFAULT_TIME_OUT=3000 npm run setChromeDriverVersion; npm run tslint && wdio src/test/wdio.conf.js --suite regression",
+    "spec": "DEFAULT_TIME_OUT=3000 npm run tslint && wdio src/test/wdio.conf.js --spec",
     "start:sampleApp": "ws --spa src/test/sampleApp/index.html"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
     "examples"
   ],
   "scripts": {
-    "tslint": "tslint -c tslint.json 'src/**/*.ts' -p ./ --fix",
+    "tslint": "tslint -c ./tslint.json 'src/**/*.ts' --fix",
     "prettier": "prettier --write 'src/**/*.ts'; prettier --write 'src/test/**/*.ts'",
     "prepack": "npm run tslint && tsc && cp -R src/helpers/ lib/helpers",
     "setChromeDriverVersion": "./src/scripts/setChromeDriverVersion.sh",
-    "test": "DEFAULT_TIME_OUT=3000 npm run setChromeDriverVersion; npm run tslint && wdio src/test/wdio.conf.js --suite regression",
-    "spec": "DEFAULT_TIME_OUT=3000 npm run tslint && wdio src/test/wdio.conf.js --spec",
+    "test": "DEFAULT_TIME_OUT=3000 npm run setChromeDriverVersion; wdio src/test/wdio.conf.js --suite regression",
+    "test:spec": "DEFAULT_TIME_OUT=3000 wdio src/test/wdio.conf.js --spec",
+    "pretest": "npm run tslint",
     "start:sampleApp": "ws --spa src/test/sampleApp/index.html"
   },
   "dependencies": {

--- a/src/commons/Reporter.ts
+++ b/src/commons/Reporter.ts
@@ -1,5 +1,5 @@
 import allureReporter from '@wdio/allure-reporter';
-import chalk, { Chalk } from 'chalk';
+import chalk from 'chalk';
 
 /**
  * Print to standard output
@@ -10,13 +10,13 @@ const printToConsole: boolean = process.env.PRINT_LOGS_TO_CONSOLE === 'true' || 
  */
 let currentTestName: string = '';
 const DEBUG: string = '[DEBUG]';
-const DEBUG_COLOR: Chalk = chalk.gray;
+const DEBUG_COLOR: chalk.Chalk = chalk.gray;
 const STEP: string = '[STEP]';
-const STEP_COLOR: Chalk = chalk.green;
+const STEP_COLOR: chalk.Chalk = chalk.green;
 const WARNING: string = '[WARNING]';
-const WARNING_COLOR: Chalk = chalk.yellow;
+const WARNING_COLOR: chalk.Chalk = chalk.yellow;
 const ERROR: string = '[ERROR]';
-const ERROR_COLOR: Chalk = chalk.red;
+const ERROR_COLOR: chalk.Chalk = chalk.red;
 
 /**
  * Custom command for use with wdio-allure-reporter
@@ -270,7 +270,7 @@ function getDate(): string {
  * @param level message level
  * @param color message color
  */
-function toConsole(msg: string, level: string, color: Chalk): void {
+function toConsole(msg: string, level: string, color: chalk.Chalk): void {
   if (printToConsole) {
     const messageToLog: string = prettyMessage(level, msg);
     console.log(color(messageToLog));

--- a/src/test/wdio.conf.js
+++ b/src/test/wdio.conf.js
@@ -8,8 +8,8 @@ const waitForTimeouts = parseInt(process.env.DEFAULT_TIME_OUT) || 3000;
  *
  */
 exports.config = {
-  specs: ['./lib/test/specs/**/*Spec.js'],
-  suites: { regression: ['./lib/test/specs/**/*Spec.js'] },
+  specs: ['./src/test/specs/**/*Spec.ts'],
+  suites: { regression: ['./src/test/specs/**/*Spec.ts'] },
 
   // Browser capabilities
   capabilities: [
@@ -62,6 +62,9 @@ exports.config = {
   // before running any tests.
   framework: 'mocha',
   mochaOpts: {
+    ui: 'bdd',
     timeout: 300000,
+    // TypeScript setup
+    require: 'ts-node/register',
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "esModuleInterop": true                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
   },
-  "exclude": ["node_modules", "lib"],
+  "exclude": ["node_modules", "lib", "src/test"],
   "compileOnSave": false
 }


### PR DESCRIPTION
introducing TS-node to the project. 
No need to compile the ts files separately now. 
Just use **npm run spec ./src/test/specs/ExpectTextSpec.ts** or **npm test** for tests execution

package JSON scripts were updated
wdio conf updated
some small fixes in chalk import