### PR TITLE
remove-double-space-in-report-log-entry

### DIFF
--- a/src/commons/Reporter.ts
+++ b/src/commons/Reporter.ts
@@ -250,7 +250,7 @@ export namespace Reporter {
 function prettyMessage(logLevel: string, msg: string): string {
   const dateString: string = getDate();
 
-  return `${dateString} ${currentTestName} ${logLevel} ${msg}`;
+  return `${dateString}${currentTestName !== '' ? ` ${currentTestName} ` : ' '}${logLevel} ${msg}`;
 }
 
 /**


### PR DESCRIPTION
in case test name not provided to report, handle the double space 