### PR TITLE
Fix missing return type on function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     '@typescript-eslint/no-inferrable-types': 0,
     '@typescript-eslint/ban-types': 0,
     '@typescript-eslint/no-namespace': 0,
+    '@typescript-eslint/explicit-module-boundary-types': ['error'],
     '@typescript-eslint/array-type': ['error', { default: 'generic' }],
     '@typescript-eslint/no-explicit-any': ['error'],
   },

--- a/src/commons/Reporter.ts
+++ b/src/commons/Reporter.ts
@@ -189,7 +189,7 @@ export namespace Reporter {
    * @param name name of the label
    * @param value value of the label
    */
-  export function addLabel(name: string, value: string) {
+  export function addLabel(name: string, value: string): void {
     allureReporter.addLabel(name, value);
   }
 


### PR DESCRIPTION
update linter config and fix error explicit-module-boundary-types