### PR TITLE
fix: fix-browser-logs-allure

### DIFF
--- a/src/commons/AllureReport.ts
+++ b/src/commons/AllureReport.ts
@@ -55,11 +55,7 @@ export namespace AllureReporter {
     networkActivity: Array<object>
   ): void {
     if (isFailed) {
-      allureReporter.addAttachment(
-        'Browser console logs',
-        JSON.stringify(browserLogs, undefined, 2),
-        'application/json'
-      );
+      allureReporter.addAttachment('Browser console logs', browserLogs, 'application/json');
 
       allureReporter.addAttachment('Page HTML source', pageSource, 'html');
 


### PR DESCRIPTION
fix browser logs displayed in allure as string instead of JSON