### PR TITLE
test: add suffix to filename for compare with snapshot

### DIFF
--- a/src/commons/BrowserUtils.ts
+++ b/src/commons/BrowserUtils.ts
@@ -17,7 +17,7 @@ import {
 } from 'webdriverio';
 import { Location } from 'webdriverio/build/commands/element/getLocation';
 import { Size } from 'webdriverio/build/commands/element/getSize';
-import { SpecialKeys } from '..';
+import { SpecialKeys, TestUtils } from '..';
 import { MouseButton } from '../enums/MouseButton';
 import { SelectorType } from '../enums/SelectorType';
 import { Reporter } from './Reporter';
@@ -32,38 +32,12 @@ export interface IComparisonPath {
   diffPath: string;
 }
 
-const sanitizeString = (str = '') =>
-  str
-    .trim()
-    .replace(/[^a-z0-9]/gi, '_')
-    .toLowerCase();
-
-//this is working because we are setting those values in a beforeTest hook in wdio config
-const getFilename = (filenameSuffix) => {
-  const testcaseNameSanitized = sanitizeString(global?.currentTest?.title);
-  const filenameSanitized = sanitizeString(path.basename(global?.currentTest?.file || ''));
-
-  if (!testcaseNameSanitized || !filenameSanitized) {
-    console.warn(
-      'cannot read current test title or filename, make sure you set the "currentTest" as a global variable'
-    );
-
-    return filenameSuffix || '';
-  }
-
-  let filename = `${filenameSanitized}-${testcaseNameSanitized}`;
-
-  if (filenameSuffix) {
-    filename += '-' + filenameSuffix;
-  }
-
-  return filename;
-};
-
 /**
  * BrowserUtils wraps wdio browser functionality for cleaner test
  */
 export namespace BrowserUtils {
+  import getFilename = TestUtils.getFilename;
+
   /**
    * Check element's visualisation
    * For more information see https://github.com/wswebcreation/wdio-image-comparison-service

--- a/src/commons/TestUtils.ts
+++ b/src/commons/TestUtils.ts
@@ -69,4 +69,40 @@ export namespace TestUtils {
     );
     return data && data[dataTag];
   }
+
+  const sanitizeString = (str = '') =>
+    str
+      .trim()
+      .replace(/[^a-z0-9]/gi, '_')
+      .toLowerCase();
+
+  /**
+   * Get file name from
+   * @param filenameSuffix
+   * example of wfio.config
+   * beforeTest: function (test, context) {
+   *     global.currentTest = test;
+   *     global.currentContext = context;
+   *   },
+   */
+  export const getFilename = (filenameSuffix: string): string => {
+    const testcaseNameSanitized = sanitizeString(global?.currentTest?.title);
+    const filenameSanitized = sanitizeString(path.basename(global?.currentTest?.file || ''));
+
+    if (!testcaseNameSanitized || !filenameSanitized) {
+      console.warn(
+        'cannot read current test title or filename, make sure you set the "currentTest" as a global variable'
+      );
+
+      return filenameSuffix || '';
+    }
+
+    let filename = `${filenameSanitized}-${testcaseNameSanitized}`;
+
+    if (filenameSuffix) {
+      filename += '-' + filenameSuffix;
+    }
+
+    return filename;
+  };
 }

--- a/src/commons/TestUtils.ts
+++ b/src/commons/TestUtils.ts
@@ -86,8 +86,8 @@ export namespace TestUtils {
    *   },
    */
   export const getFilename = (filenameSuffix: string): string => {
-    const testcaseNameSanitized = sanitizeString(global?.currentTest?.title);
-    const filenameSanitized = sanitizeString(path.basename(global?.currentTest?.file || ''));
+    const testcaseNameSanitized: string = sanitizeString(global?.currentTest?.title);
+    const filenameSanitized: string = sanitizeString(path.basename(global?.currentTest?.file || ''));
 
     if (!testcaseNameSanitized || !filenameSanitized) {
       console.warn(
@@ -97,7 +97,7 @@ export namespace TestUtils {
       return filenameSuffix || '';
     }
 
-    let filename = `${filenameSanitized}-${testcaseNameSanitized}`;
+    let filename: string = `${filenameSanitized}-${testcaseNameSanitized}`;
 
     if (filenameSuffix) {
       filename += '-' + filenameSuffix;


### PR DESCRIPTION
## Brief Summary of Changes
-
<!--
adding suffix to file: for example compareWithSnapshot('good talk') will create file `good_talk.png` instead of `good talk.png`
-->

## Reviewer, Please Note:
-
<!--
List anything here that the reviewer should pay special attention to.
-->

## Testing (what was tested)
- 
