### PR TITLE
feat: bump compare image dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ts-node": "^10.8.2",
     "tsconfig-paths": "^3.14.1",
     "wdio-docker-service": "^3.2.0",
-    "wdio-image-comparison-service": "^3.1.0",
+    "wdio-image-comparison-service": "5.0.3",
     "webdriverio": "8.14.3",
     "yargs": "^17.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ dependencies:
     specifier: ^3.2.0
     version: 3.2.0
   wdio-image-comparison-service:
-    specifier: ^3.1.0
-    version: 3.1.0
+    specifier: 5.0.3
+    version: 5.0.3
   webdriverio:
     specifier: 8.14.3
     version: 8.14.3(typescript@4.7.4)
@@ -7850,21 +7850,20 @@ packages:
       - encoding
     dev: false
 
-  /wdio-image-comparison-service@3.1.0:
-    resolution: {integrity: sha512-LghpI8bXdXxzU4ErRI/8nCKaoD15pmXoGY3FBloZ2PSj1UM63ojsDCJs1Aakk08epS5gTiBxNBlR4zt9GOZ0mA==}
+  /wdio-image-comparison-service@5.0.3:
+    resolution: {integrity: sha512-KCmuML6rFpFutRacxK4hX1JUK1JxRF1B3trJryWyhlY0A27EHiFlgoLcp8GBA9RGhQrkUDJKWKmLW37fQKbESw==}
     dependencies:
       '@wdio/logger': 7.26.0
-      webdriver-image-comparison: 0.20.2
+      webdriver-image-comparison: 1.0.3
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /webdriver-image-comparison@0.20.2:
-    resolution: {integrity: sha512-vl/fOLIkaenecobKQx57wu3nbtyRJE/O11mwpXivuXEVzD3yP9eh3G8iYh4IEIreEMCXxYBC3q4wHw2zLaxbDA==}
+  /webdriver-image-comparison@1.0.3:
+    resolution: {integrity: sha512-R23Jj++AnXP57qU4Kly44ZC1r91JZhr78k0gEu1PLmRTTrzM4QV7QoXfOC+5zoFUal+XiqBAU+YPRGr7l/+kHA==}
     dependencies:
       canvas: 2.11.2
-      chalk: 4.1.2
       fs-extra: 10.1.0
     transitivePeerDependencies:
       - encoding


### PR DESCRIPTION
BREAKING CHANGE: bump compare image dependency version to 5

## Brief Summary of Changes
- bump compare image version to support node 20 version
<!--
Provide some context as to what was changed, from an implementation standpoint.
-->

## Reviewer, Please Note:
-
<!--
List anything here that the reviewer should pay special attention to.
-->

## Testing (what was tested)
- 
